### PR TITLE
Do not grab events with shift

### DIFF
--- a/packages/Autocompletion.package/ECController.class/instance/handleMenuShortcuts..st
+++ b/packages/Autocompletion.package/ECController.class/instance/handleMenuShortcuts..st
@@ -2,6 +2,8 @@ keyboard
 handleMenuShortcuts: aKeyboardEvent
 
 	| theEditor keyCharacter controlKeyPressed commandKeyPressed |
+	aKeyboardEvent shiftPressed ifTrue: [self closeMenu. ^ false].
+	
 	theEditor := self editor.
 	keyCharacter := aKeyboardEvent keyCharacter.
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.


### PR DESCRIPTION
For example, when I am typing something and using Shift + Arrow down, I would like to select the line but not the next Autocompletion proposal.