### PR TITLE
Allow overriding in Debugger

### DIFF
--- a/packages/Autocompletion.package/Debugger.extension/instance/completionControllerClass.st
+++ b/packages/Autocompletion.package/Debugger.extension/instance/completionControllerClass.st
@@ -1,0 +1,6 @@
+*Autocompletion
+completionControllerClass
+
+	^ ECPreferences useECompletionInsteadOfOCompletion
+		ifFalse: [ OController ]
+		ifTrue: [ ECBrowserController ]

--- a/packages/Autocompletion.package/Debugger.extension/methodProperties.json
+++ b/packages/Autocompletion.package/Debugger.extension/methodProperties.json
@@ -2,4 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
+		"completionControllerClass" : "CT 7/20/2019 17:25",
 		"guessTypeForName:" : "JohanBrichau 10/21/2009 19:37" } }

--- a/packages/Autocompletion.package/monticello.meta/package
+++ b/packages/Autocompletion.package/monticello.meta/package
@@ -1,1 +1,0 @@
-(name 'Autocompletion')

--- a/packages/Autocompletion.package/monticello.meta/version
+++ b/packages/Autocompletion.package/monticello.meta/version
@@ -1,1 +1,0 @@
-(name 'Autocompletion-squot.3739357102' message 'created from a Squot Artifact.' id '6f437346-46e5-b645-93bc-d2bba88412ac' date '30 June 2019' time '2:18:22.449781 pm' author '' ancestors () stepChildren ())


### PR DESCRIPTION
With this pull request, class-specific suggestions in Debugger's code pane work. Before they didn't, as the shout parser called in ECContext was not told to parse a method.

(By the way: Please let me know if I made any formal errors while creating this pull request. GitHub warned me this branch is 5 commits behind MrModder:master, but I don't know how to fix this.)