### PR TITLE
Fix type guessing of instance variables in `ContextVariablesInspector`

### DIFF
--- a/packages/Autocompletion.package/ContextVariablesInspector.extension/instance/guessTypeForName..st
+++ b/packages/Autocompletion.package/ContextVariablesInspector.extension/instance/guessTypeForName..st
@@ -2,8 +2,8 @@
 guessTypeForName: aString
 
 	| index |
-	self doItContext ifNil: [^ nil].
+	self doItContext ifNil: [^ super guessTypeForName: aString].
 	index := (self doItContext debuggerMap tempNamesForContext: self doItContext)
 		indexOf: aString
-		ifAbsent: [^ nil].
+		ifAbsent: [^ super guessTypeForName: aString].
 	^ (self doItContext tempAt: index) class

--- a/packages/Autocompletion.package/ContextVariablesInspector.extension/methodProperties.json
+++ b/packages/Autocompletion.package/ContextVariablesInspector.extension/methodProperties.json
@@ -3,4 +3,4 @@
 		 },
 	"instance" : {
 		"completionAdditionals" : "LM 11/1/2021 21:13",
-		"guessTypeForName:" : "LM 11/1/2021 21:17" } }
+		"guessTypeForName:" : "ct 11/14/2021 18:23" } }


### PR DESCRIPTION
This commit addresses a regression from ea404b3, which resulted in type guessing being no longer available in `ContextVariablesInspector`s for normal instance variables as there was no send to super.

Before:

![image](https://user-images.githubusercontent.com/38782922/141693753-10a2638e-aa5c-4591-a525-38f85cf37817.png)

After:

![image](https://user-images.githubusercontent.com/38782922/141693756-459913c9-c029-42f3-8a94-ace4cad96f25.png)
