### PR TITLE
Fix exception handling in `ECContext`

### DIFF
--- a/packages/Autocompletion.package/.squot-contents
+++ b/packages/Autocompletion.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ '9d7aeb90f9f6124d9c93b2b8c6d24c81' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/Autocompletion.package/ECContext.class/class/allErrors.st
+++ b/packages/Autocompletion.package/ECContext.class/class/allErrors.st
@@ -1,0 +1,4 @@
+accessing
+allErrors
+
+	^ Error, Warning", Halt"

--- a/packages/Autocompletion.package/ECContext.class/instance/createModel.st
+++ b/packages/Autocompletion.package/ECContext.class/instance/createModel.st
@@ -1,7 +1,7 @@
 accessing
 createModel
 	^ [self tryCreateModel]
-		on: Exception
+		on: self class allErrors
 		do: [:error | ECUntypedModel new
 				handleException: error;
 				yourself]

--- a/packages/Autocompletion.package/ECContext.class/instance/narrowWith..st
+++ b/packages/Autocompletion.package/ECContext.class/instance/narrowWith..st
@@ -1,4 +1,4 @@
 action
 narrowWith: aString 
 	completionToken := aString.
-	[self model narrowWith: aString] on: Exception do: [:exception | model handleException: exception]
+	[self model narrowWith: aString] on: self class allErrors do: [:exception | model handleException: exception]

--- a/packages/Autocompletion.package/ECContext.class/instance/setController.class.source.position..st
+++ b/packages/Autocompletion.package/ECContext.class/instance/setController.class.source.position..st
@@ -7,6 +7,6 @@ setController: aECController class: aClass source: aString position: anInteger
 	
 	[self createRanges.
 	self compute]
-		on: Exception
+		on: self class allErrors
 		do: [:exception | self model handleException: exception].
 	self narrowWith: self completionToken.

--- a/packages/Autocompletion.package/ECContext.class/methodProperties.json
+++ b/packages/Autocompletion.package/ECContext.class/methodProperties.json
@@ -1,5 +1,6 @@
 {
 	"class" : {
+		"allErrors" : "ct 7/2/2022 21:03",
 		"controller:class:source:position:" : "bar 4/11/2005 11:23" },
 	"instance" : {
 		"blockTemporaries" : "lr 7/4/2009 10:42",
@@ -15,7 +16,7 @@
 		"convertBlocksToVariables:" : "lr 7/4/2009 10:42",
 		"createEmptyRangeAtTail" : "lr 7/4/2009 10:42",
 		"createEmptyRangeForGapAt:" : "RomainRobbes 11/2/2009 07:57",
-		"createModel" : "LM 11/16/2020 22:18",
+		"createModel" : "ct 7/2/2022 21:03",
 		"createRanges" : "LM 3/20/2019 18:28",
 		"findCommonSuperclass:" : "lr 3/26/2010 15:04",
 		"findSourceRangeFor:" : "LM 11/1/2018 21:29",
@@ -38,9 +39,9 @@
 		"isSelectorsOnly" : "bar 1/9/2005 11:33",
 		"isVariablesOnly" : "lr 7/4/2009 10:42",
 		"model" : "LM 11/16/2020 22:10",
-		"narrowWith:" : "LM 11/16/2020 22:12",
+		"narrowWith:" : "ct 7/2/2022 21:03",
 		"receiverClass" : "bar 12/13/2004 15:32",
-		"setController:class:source:position:" : "LM 11/16/2020 22:17",
+		"setController:class:source:position:" : "ct 7/2/2022 21:04",
 		"sourceOf:" : "bar 3/1/2006 13:25",
 		"sourceOf:stopAt:" : "bar 12/18/2004 23:55",
 		"switchToUntyped" : "LM 11/16/2020 21:52",

--- a/packages/BaselineOfAutocompletion.package/.squot-contents
+++ b/packages/BaselineOfAutocompletion.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ 'e931af5edd66f04e8203b9fa012f8fe9' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }


### PR DESCRIPTION
Handling `Exception` is considered an anti-pattern, as there are also many non-breaking exceptions such as notifications that occur from time to time. See the comment in `Exception`. Furthermore, not catching all halts improves the debuggability of the tool.