### PR TITLE
Proposal: Automatically disable autocompletion for models that reject Shout styling

### DIFF
--- a/packages/Autocompletion.package/.squot-contents
+++ b/packages/Autocompletion.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ '9d7aeb90f9f6124d9c93b2b8c6d24c81' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/Autocompletion.package/StringHolder.extension/instance/wantsAutocompletion.st
+++ b/packages/Autocompletion.package/StringHolder.extension/instance/wantsAutocompletion.st
@@ -1,5 +1,16 @@
 *Autocompletion
 wantsAutocompletion
-
-	^ [self aboutToStyle: MessageCatcher new requestor: nil]
+	"Do I want to be decorated with an Autocompletion menu?"
+	
+	"Heuristic: Most models hold autocompletable contents if and only if they opt-in to syntax highlighting. Try to reuse this information if a styler is available."
+	| styler stylerClass |
+	stylerClass := (Smalltalk classNamed: #TextStyler) ">= Squeak 6.0"
+		ifNotNil: [:registry | registry defaultOrNil]
+		ifNil: [Smalltalk classNamed: #SHTextStylerST80 "optional dependency on Shout"].
+	stylerClass ifNil:
+		["fallback"
+		^ true].
+	
+	styler := stylerClass new.
+	^ [self aboutToStyle: styler requestor: nil]
 		ifError: [:ex | Transcript showln: ex. false]

--- a/packages/Autocompletion.package/StringHolder.extension/instance/wantsAutocompletion.st
+++ b/packages/Autocompletion.package/StringHolder.extension/instance/wantsAutocompletion.st
@@ -1,4 +1,5 @@
 *Autocompletion
 wantsAutocompletion
 
-	^ true
+	^ [self aboutToStyle: MessageCatcher new requestor: nil]
+		ifError: [:ex | Transcript showln: ex. false]

--- a/packages/Autocompletion.package/StringHolder.extension/methodProperties.json
+++ b/packages/Autocompletion.package/StringHolder.extension/methodProperties.json
@@ -6,4 +6,4 @@
 		"createCompletionController" : "LM 5/4/2020 18:23",
 		"guessTypeForName:" : "LM 5/4/2020 18:23",
 		"initializeCompletionController" : "LM 5/4/2020 18:23",
-		"wantsAutocompletion" : "ct 7/2/2022 22:15" } }
+		"wantsAutocompletion" : "ct 10/4/2022 19:13" } }

--- a/packages/Autocompletion.package/StringHolder.extension/methodProperties.json
+++ b/packages/Autocompletion.package/StringHolder.extension/methodProperties.json
@@ -6,4 +6,4 @@
 		"createCompletionController" : "LM 5/4/2020 18:23",
 		"guessTypeForName:" : "LM 5/4/2020 18:23",
 		"initializeCompletionController" : "LM 5/4/2020 18:23",
-		"wantsAutocompletion" : "LM 6/30/2019 14:09" } }
+		"wantsAutocompletion" : "ct 7/2/2022 22:15" } }

--- a/packages/BaselineOfAutocompletion.package/.squot-contents
+++ b/packages/BaselineOfAutocompletion.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ 'e931af5edd66f04e8203b9fa012f8fe9' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }


### PR DESCRIPTION
## Reasoning

Both Autocompletion and Shout follow two relatively similar goals, i.e., to enhance the editing support in arbitrary tools that display source code. By using a simple heuristic that adopts the decision of a tool whether its contents should be syntax-highlighted, we can reduce the adaptation effort of tools for Autocompletion. Since Shout is already a part of the base system, a vast majority of tools can be assumed to implement proper information for syntax highlighting.

## Implementation

In `StringHolder >> #wantsAutocompletion`, redirect to `#aboutToStyle:requestor:` and pass a pseudo-styler (`MessageCatcher`) and a `nil` requestor. For the unlikely event that anything breaks (because some tool might expect a non-nil requestor or a certain styler type), catch any errors, log them to the transcript, and reject autocompletion.

## Considerations

- [x] `#aboutToStyle:requestor:` (with the second argument) is a relatively new selector that is only included in Squeak 5.3 and newer. If Autocompletion intends to provide further backward compatibility, a version switch could be introduced.

  **What backward compatibility should be supported?**

- [x] For the pseudo-styler, a more reliable alternative to using a generic `MessageCatcher` could be instantiating a real `SHStylerST80`. However, this would add a hard dependency on Shout whereas, at the moment, we only rely on the existence of the `#aboutToStyle:requestor:` protocol which is part of the Kernel package.

  **Is it okay to stick with the current `MessageCatcher` approach?**

## Impressions

### Workspace

<p float="middle">
<img width="45%" src="https://user-images.githubusercontent.com/38782922/177015357-87ac0ca0-0fe9-4c50-ab19-4859bf2dc2fd.png">
<img width="45%" src="https://user-images.githubusercontent.com/38782922/177015347-a7430dc4-088d-4cd5-9d8c-7a033dabc0fb.png">
</p>

### Browser

<p float="middle">
<img width="30%" src="https://user-images.githubusercontent.com/38782922/177015386-76769f1a-a7b4-4428-80db-b177282876f2.png">
<img width="30%" src="https://user-images.githubusercontent.com/38782922/177015391-81a9b28e-2991-43b8-a7f5-67eacfec00ae.png">
<img width="30%" src="https://user-images.githubusercontent.com/38782922/177015409-42221c6f-591b-45af-9ea6-ea34946d4abb.png">
</p>

