### PR TITLE
Fix `ECExceptionEntry printString`

### DIFF
--- a/packages/Autocompletion.package/ECExceptionEntry.class/instance/initialize.st
+++ b/packages/Autocompletion.package/ECExceptionEntry.class/instance/initialize.st
@@ -1,0 +1,6 @@
+initialize-release
+initialize
+
+	super initialize.
+	
+	type := #exception.

--- a/packages/Autocompletion.package/ECExceptionEntry.class/methodProperties.json
+++ b/packages/Autocompletion.package/ECExceptionEntry.class/methodProperties.json
@@ -8,6 +8,7 @@
 		"exception:" : "LM 11/1/2021 20:52",
 		"helperProcess" : "LM 11/16/2020 19:08",
 		"helperProcess:" : "LM 11/16/2020 19:08",
+		"initialize" : "ct 12/21/2023 18:37",
 		"label" : "LM 11/16/2020 19:17",
 		"matchNarrowString:" : "LM 11/16/2020 21:53",
 		"selectColor" : "LM 11/16/2020 21:34" } }


### PR DESCRIPTION
This does not bubble up to the UI, but sane printStrings are helpful for debugging/development anyway of course ...