### PR TITLE
Revise entry sorting: refactor for readability, remove duplicates, sort rest alphabetically

### DIFF
--- a/packages/Autocompletion.package/ECModel.class/instance/sortEntries.st
+++ b/packages/Autocompletion.package/ECModel.class/instance/sortEntries.st
@@ -1,9 +1,13 @@
 accessing
 sortEntries
 
-	entries sort: [:aEntry :bEntry | | aPriority bPriority |
-		aPriority := aEntry matchNarrowString: narrowString.
-		bPriority := bEntry matchNarrowString: narrowString.
-		aPriority = bPriority
-			ifTrue: [aEntry <= bEntry]
-			ifFalse: [aPriority >= bPriority]]
+	| seen |
+	entries sort:
+		[:entry | entry matchNarrowString: narrowString] descending
+			, [:aEntry :bEntry | aEntry <= bEntry ifTrue: [-1] ifFalse: [0]]
+			, [:aEntry :bEntry | (aEntry contents compare: bEntry contents caseSensitive: ECPreferences caseSensitive) - 2].
+	
+	"remove any duplicates"
+	seen := Set new.
+	entries removeAllSuchThat: [:entry |
+		(seen ifAbsentAdd: entry contents) not].

--- a/packages/Autocompletion.package/ECModel.class/methodProperties.json
+++ b/packages/Autocompletion.package/ECModel.class/methodProperties.json
@@ -24,7 +24,7 @@
 		"resetSelectors" : "ul 9/26/2010 19:23",
 		"selectorsAsSymbols" : "LM 3/20/2019 15:23",
 		"setClass:" : "bar 1/6/2005 08:54",
-		"sortEntries" : "LM 4/9/2019 16:37",
+		"sortEntries" : "ct 12/21/2023 20:27",
 		"theClass" : "bar 3/1/2006 15:48",
 		"title" : "bar 12/6/2004 14:44",
 		"toggleExpand" : "bar 12/5/2004 23:17" } }


### PR DESCRIPTION
Duplicates can occur for variables that are also selectors in untyped models, or also due to custom hooks.