### PR TITLE
Exclude invalid selectors

### DIFF
--- a/packages/Autocompletion.package/ECSymbols.class/class/contains.caseSensitive.exclude.do..st
+++ b/packages/Autocompletion.package/ECSymbols.class/class/contains.caseSensitive.exclude.do..st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing
 contains: aString caseSensitive: aBoolean exclude: aCollection do: aBlock
 
 	| separators |
@@ -7,5 +7,6 @@ contains: aString caseSensitive: aBoolean exclude: aCollection do: aBlock
 	separators := CharacterSet separators.
 	Symbol allSymbolTablesDo: [:each | 
 		((each indexOfAnyOf: separators startingAt: 1) = 0 and: [(aCollection includes: each) not]
-			and: [each includesSubstring: aString caseSensitive: aBoolean])
+			and: [(each includesSubstring: aString caseSensitive: aBoolean)
+			and: [self isValidSelector: each]])
 				ifTrue: [aBlock value: each]].

--- a/packages/Autocompletion.package/ECSymbols.class/class/isValidSelector..st
+++ b/packages/Autocompletion.package/ECSymbols.class/class/isValidSelector..st
@@ -1,0 +1,6 @@
+testing
+isValidSelector: aSymbol
+	
+	"ct: ~24% faster than uncached (58ms vs 75ms for Symbol allSymbols)"
+	^ (SymbolValidities ifNil: [SymbolValidities := WeakIdentityKeyDictionary new])
+		at: aSymbol ifAbsentPut: [aSymbol isMessageSelector]

--- a/packages/Autocompletion.package/ECSymbols.class/methodProperties.json
+++ b/packages/Autocompletion.package/ECSymbols.class/methodProperties.json
@@ -1,6 +1,7 @@
 {
 	"class" : {
 		"contains:caseSensitive:do:" : "LM 3/20/2019 15:22",
-		"contains:caseSensitive:exclude:do:" : "LM 3/20/2019 15:22" },
+		"contains:caseSensitive:exclude:do:" : "ct 12/21/2023 21:00",
+		"isValidSelector:" : "ct 12/21/2023 21:05" },
 	"instance" : {
 		 } }

--- a/packages/Autocompletion.package/ECSymbols.class/properties.json
+++ b/packages/Autocompletion.package/ECSymbols.class/properties.json
@@ -3,7 +3,7 @@
 	"classinstvars" : [
 		 ],
 	"classvars" : [
-		 ],
+		"SymbolValidities" ],
 	"commentStamp" : "",
 	"instvars" : [
 		 ],


### PR DESCRIPTION
No more 'Preferences>>defaultAnnotationRequests' or '*Etoys-examples' as completion selectors!

NB: Maybe `ECSymbols` should be renamed to `ECSelectors`? Or not worth the effort? :)